### PR TITLE
cron suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Puppet Face to retrieve the node count from PuppetDB.
 ## Setup
 
 Install the module via Code Manager or r10k and then run Puppet.
+If you would like to gather historical node count statistics to a file, include the provided class `facecount` on your Puppet Enterprise Master either through Puppet Code or the [Node Classifier](https://docs.puppet.com/pe/latest/console_classes_groups.html) and statistics will be collected into the file `/var/log/puppetlabs/node_count.txt` for you and updated every 30 minutes.
 
 ## Usage
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,14 @@
+# Include this class in your Puppet Master/Master Of Masters to create
+# a CSV logfile of your node counts to /var/log/puppetlabs/node_count.txt
+class facecount($frequency = 30) {
+  $logfile  = "/var/log/puppetlabs/node_count.txt"
+  $date     = "date -u  --iso-8601=minutes"
+  $command  = "echo \$(${date}), \$(/opt/puppetlabs/puppet/bin/puppet node count) >> ${logfile}" 
+
+  cron { 'puppet_node_counts':
+    ensure  => present,
+    command => $command,
+    user    => 'root',
+    minute  => "*/${frequency}",
+  }
+}


### PR DESCRIPTION
Adds a class providing support to gather historical node counts in CSV to a file at `var/log/puppetlabs/node_count.txt`

Output looks like this (taken every minute for testing - default is every 30 minutes):
```
2016-11-23T01:28+0000, Node count: 2
2016-11-23T01:29+0000, Node count: 2
2016-11-23T01:30+0000, Node count: 2
2016-11-23T01:31+0000, Node count: 2
2016-11-23T01:32+0000, Node count: 2
2016-11-23T01:33+0000, Node count: 2
2016-11-23T01:34+0000, Node count: 2
2016-11-23T01:35+0000, Node count: 2
2016-11-23T01:36+0000, Node count: 2
2016-11-23T01:37+0000, Node count: 2
2016-11-23T01:38+0000, Node count: 2
2016-11-23T01:39+0000, Node count: 2
2016-11-23T01:40+0000, Node count: 2
2016-11-23T01:41+0000, Node count: 2
2016-11-23T01:42+0000, Node count: 2
```

Includes updated documentation